### PR TITLE
fix: accept neutral checks as succeeded

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -141,7 +141,7 @@ const run = async () => {
     })
 
     const allChecksHaveSucceeded = checkRuns.data.check_runs.every(
-      (run) => run.conclusion === 'success'
+      (run) => run.conclusion === 'success' || run.conclusion === 'neutral'
     )
     if (!allChecksHaveSucceeded) {
       info('All checks did not succeed')


### PR DESCRIPTION
Without this change, checks such as https://lgtm.com/ will prevent prs from being merged. 