### PR TITLE
Don't consider skipped jobs as the pipeline having failed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -123,7 +123,9 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
             repo,
             ref: lastCommitHash,
         });
-        const allChecksHaveSucceeded = checkRuns.data.check_runs.every((run) => run.conclusion === 'success' || run.conclusion === 'neutral');
+        const nonSkippedCheckRuns = checkRuns.data.check_runs.filter((run) => run.conclusion !== 'skipped');
+        const allChecksHaveSucceeded = nonSkippedCheckRuns.length > 0 &&
+            nonSkippedCheckRuns.every((run) => run.conclusion === 'success' || run.conclusion === 'neutral');
         if (!allChecksHaveSucceeded) {
             info('All checks did not succeed');
             debugJSON(checkRuns.data);

--- a/index.ts
+++ b/index.ts
@@ -142,9 +142,15 @@ const run = async () => {
       ref: lastCommitHash,
     })
 
-    const allChecksHaveSucceeded = checkRuns.data.check_runs.every(
-      (run) => run.conclusion === 'success' || run.conclusion === 'neutral'
+    const nonSkippedCheckRuns = checkRuns.data.check_runs.filter(
+      (run) => run.conclusion !== 'skipped'
     )
+
+    const allChecksHaveSucceeded =
+      nonSkippedCheckRuns.length > 0 &&
+      nonSkippedCheckRuns.every(
+        (run) => run.conclusion === 'success' || run.conclusion === 'neutral'
+      )
     if (!allChecksHaveSucceeded) {
       info('All checks did not succeed')
       debugJSON(checkRuns.data)


### PR DESCRIPTION
**TL;DR:** Don't consider the CI run for the Dependabot PR to have failed, if all the other jobs in the pipeline succeeded but one (or more) of them was skipped.

## Background

Consider the following GitHub Actions configuration:

```yaml
name: CI

on:
  pull_request:
  push:
    branches:
      - master

jobs:
  build:
    name: Build
    runs-on: ubuntu-latest
    steps:
        # (...)

  test:
    name: Run tests
    runs-on: ubuntu-latest
    needs: [build]
    steps:
      # (...)

  push-docker-images:
    name: Push Docker images
    runs-on: ubuntu-latest
    needs: [lint, build, test]
    if: github.ref == 'refs/heads/main'
    steps:
      # (...)
```

In other words, we have a CI pipeline that runs most steps for both pushes to master and for pull requests, apart from one entire step (in this example case, pushing some Docker images somewhere).

In its current iteration, when this type of run configuration runs for a pull request and succeeds, `dependabot-cron-action` will nonetheless consider the pipeline to have failed. Why? Because, in this case, for just one of the jobs, `run.conclusion` is neither `success` nor `neutral`, it's `skipped`. https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow--parameters

I would argue one check being skipped is not indicative of the pipeline having failed. If the entire pipeline is skipped, then we need to consider it slightly differently.

The way I chose to think about it is thus: **Would I want a Dependabot PR to be merged or not merged under the following conditions?**
- If all other jobs in the pipeline succeeded, but one was skipped: **Yes.** All checks that should run, ran, and succeeded, therefore the pipeline has succeeded.
- If all jobs in the pipeline were skipped: **No.** No checks that should run, ran, and therefore we cannot make a judgement on their success; therefore, the pipeline has failed.

To avoid ending up with `[].every((run) => run.conclusion === 'success' || run.conclusion === 'neutral')` after filtering out all the skipped jobs (since `[].every()` is `true`), I added a check that we must at least have one non-skipped job that has run in order to consider whether all of them succeeded. 

Summa summarum: Let's filter out skipped steps in the pipeline before we check for step failures (and check at least one job ran, in order to make a judgement on the pipeline's success).