### PR TITLE
fix: update approval logic to avoid merge on undefined versionBump

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -182,7 +182,7 @@ const run = async () => {
       (versionBump === 'major' && autoMerge === 'major') ||
       (versionBump === 'minor' &&
         (autoMerge === 'major' || autoMerge === 'minor')) ||
-      (versionBump !== 'major' && versionBump !== 'minor')
+      versionBump === 'patch'
     ) {
       info('Approve and merge')
       await approve(octokit, { owner, repo, prNumber })


### PR DESCRIPTION
Fix #5 

I have updated the condition to explicitly handle major, minor, and patch version bumps according to the auto-merge configuration. This ensures that only valid semantic version bumps are merged and respects the hierarchy (major > minor > patch).
It also avoid merge if unexpected semver version is parsed resulting in undefined versionBump

