### PR TITLE
fix: build dist/index.js and add merge retry logic

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -148,7 +148,7 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
         if ((versionBump === 'major' && autoMerge === 'major') ||
             (versionBump === 'minor' &&
                 (autoMerge === 'major' || autoMerge === 'minor')) ||
-            (versionBump !== 'major' && versionBump !== 'minor')) {
+            versionBump === 'patch') {
             info('Approve and merge');
             yield approve(octokit, { owner, repo, prNumber });
             yield merge(octokit, { owner, repo, prNumber, mergeMethod });

--- a/dist/index.js
+++ b/dist/index.js
@@ -86,20 +86,26 @@ const approve = (octokit, options) => __awaiter(void 0, void 0, void 0, function
     }
 });
 const merge = (octokit, options) => __awaiter(void 0, void 0, void 0, function* () {
-    try {
-        yield octokit.rest.pulls.merge({
-            owner: options.owner,
-            repo: options.repo,
-            pull_number: options.prNumber,
-            merge_method: options.mergeMethod,
-        });
-        return true;
+    const retries = 3;
+    for (let i = 1; i <= retries; i++) {
+        try {
+            yield octokit.rest.pulls.merge({
+                owner: options.owner,
+                repo: options.repo,
+                pull_number: options.prNumber,
+                merge_method: options.mergeMethod,
+            });
+            return true;
+        }
+        catch (err) {
+            info(`Merge failed (attempt ${i}/${retries}): ${err.message}`);
+            debug(err);
+            if (i < retries) {
+                yield new Promise((r) => setTimeout(r, 1000));
+            }
+        }
     }
-    catch (err) {
-        info(`Merge failed: ${err.message}`);
-        debug(err);
-        return false;
-    }
+    return false;
 });
 const run = () => __awaiter(void 0, void 0, void 0, function* () {
     const token = (0, core_1.getInput)('token') || process.env.GITHUB_TOKEN;


### PR DESCRIPTION
Sorry I forgot to do a yarn build, so the index.js in the dist folder is not reflecting the last version. Can you add it and retag it ? Thanks

In the same time I added a retry logic on merge operation in order to solve unpredictable merging issue : https://github.com/cli/cli/issues/8092